### PR TITLE
Hi, I encounter a problem with dependencies, I simply changed ~> to >= and it now works :)

### DIFF
--- a/guard-sprockets.gemspec
+++ b/guard-sprockets.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "guard-sprockets"
 
-  s.add_dependency 'guard', '~> 0.2.2'
-  s.add_dependency "sprockets", '~> 2'
+  s.add_dependency 'guard', '>= 0.2.2'
+  s.add_dependency "sprockets", '>= 2'
 
   s.files        = Dir.glob('{lib}/**/*') #+ %w[LICENSE README.rdoc]
   s.require_path = 'lib'


### PR DESCRIPTION
previously, at bundle update, I had:

```
Bundler could not find compatible versions for gem "guard":
  In Gemfile:
    guard-coffeescript (~> 1.2.0) ruby depends on
      guard (>= 1.1.0) ruby
    guard-sprockets (>= 0) ruby depends on
      guard (0.2.2)
```

now it accept guard 1.3.2
