### PR TITLE
Added ability to pass an uglifier options hash with the minify option in order to change minifications settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please read [Guard doc](https://github.com/guard/guard#readme) for more informat
 :destination => 'public/js'          # change the destination folder in which the compiled assets are saved, default: 'public/javascripts'
 :asset_paths => 'app/js'             # add a directory (or on array of directories) to Sprockets' environment's load path, default: ['app/assets/javascripts']
 :asset_paths => ['app/js', 'lib/js'] # asset_paths can be a String or an Array
-:minify      => true                 # minify the JavaScript files content using Uglifier, default: false
+:minify      => true                 # minify the JavaScript files content using Uglifier. You can pass true, false, or an Uglifier options hash. default: false
                                      # be sure to add: "gem 'uglifier'" in your Gemfile
 :root_file   => 'app/js/app.js'      # if set, only this file will be compiled, default: nil
 :root_file   => ['one.js', 'two.js'] # root_file can be a String or an Array

--- a/lib/guard/sprockets.rb
+++ b/lib/guard/sprockets.rb
@@ -21,10 +21,10 @@ module Guard
       @asset_paths.each { |p| @sprockets.append_path(p) }
       @root_file.each { |f| @sprockets.append_path(Pathname.new(f).dirname) }
 
-      if @options.delete(:minify)
+      if @options[:minify]
         begin
           require 'uglifier'
-          @sprockets.js_compressor = ::Uglifier.new
+          @sprockets.js_compressor = ::Uglifier.new(@options[:minify].is_a?(Hash) ? @options[:minify] : {})
           UI.info 'Sprockets will compress output.'
         rescue LoadError => ex
           UI.error "minify: Uglifier cannot be loaded. No compression will be used.\nPlease include 'uglifier' in your Gemfile."

--- a/spec/guard/sprockets_spec.rb
+++ b/spec/guard/sprockets_spec.rb
@@ -17,7 +17,9 @@ describe Guard::Sprockets do
 
       describe 'minify' do
         it { described_class.new.sprockets.js_compressor.should be_nil }
+        it { described_class.new([], :minify => false).sprockets.js_compressor.should be_nil }
         it { described_class.new([], :minify => true).sprockets.js_compressor.should_not be_nil }
+        it { described_class.new([], :minify => { :mangle => false }).sprockets.js_compressor.should_not be_nil }
       end
 
       describe 'root_file' do


### PR DESCRIPTION
Doesn't break any existing behaviour, only augments the minify option. Test coverage included.

An example of when this comes in useful is passing:

```
:minify => { mangle => false }
```

in order to avoid variable renaming (desirable if you're using angularjs).
